### PR TITLE
Fix Python syntax error in TestDropbox.py

### DIFF
--- a/jsuarez/tools/TestDropbox.py
+++ b/jsuarez/tools/TestDropbox.py
@@ -21,7 +21,7 @@ class Server:
       MPIUtils.print(MPIUtils.ALL, 'Server Send')
       for worker in self.clients:
          MPIUtils.print(MPIUtils.ALL, 'Server Send')
-         for pack in packets()
+         for pack in packets():
             MPIUtils.isend(pack, worker, tag=worker)
 
    def reduce(self):


### PR DESCRIPTION
$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./jsuarez/tools/TestDropbox.py:24:30: E999 SyntaxError: invalid syntax
         for pack in packets()
                             ^
```