### PR TITLE
Add setup sh script to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ cd ..
 
 git clone https://github.com/openai/neural-mmo
 cd neural-mmo
+bash scripts/setup/setup.sh
 python setup.py
 ```
 


### PR DESCRIPTION
The python setup script is being listed for the neural-mmo project but I could not even run that script until the shell one was ran. This commit adds the shell setup script to the readme. Let me know if I just missed something!